### PR TITLE
fix(contributor): removed bot from contributor list

### DIFF
--- a/hooks/useContributors.ts
+++ b/hooks/useContributors.ts
@@ -30,7 +30,8 @@ export default function useContributors() {
           throw new Error('Failed to fetch contributors')
         }
         const data = await response.json()
-        setContributors(data)
+        const userData = data.filter((c: TypeContributors) => !c.login.includes('[bot]'))
+        setContributors(userData)
       } catch (err: any) {
         setError(err.message)
       } finally {


### PR DESCRIPTION
Resolves #98 

## Description
This removes the GitHub Dependabot from the contributor list by filtering the contributor data in the useContributors hook.

## Live Demo (if any)
![image](https://github.com/user-attachments/assets/185aec55-2717-4c17-b024-f2e7ba78053c)

## Note for Maintainer
> I'm also submitting an alternative fix for this issue by allowing /in/** in the next.config.js under the same avatars.githubusercontent.com hostname.So now you can choose whichever solution suits best.

## Checkout
- [x] I have read all the contributor guidelines for the repo.
