### PR TITLE
fix(avatar-pathname): added /in/** path for github avatar pathname

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,11 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+        pathname: '/in/**', // Allows all user avatars
+      },
+      {
+        protocol: 'https',
         hostname: 'ts4.mm.bing.net',
         pathname: '/**', // Allows all Participant avatars
       },

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,7 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'avatars.githubusercontent.com',
-        pathname: '/in/**', // Allows all user avatars
+        pathname: '/in/**', // Allows all organization avatars
       },
       {
         protocol: 'https',


### PR DESCRIPTION
Resolves #98 

## Description
Added support for bot avatars by allowing /in/** in next.config.js

## Live Demo (if any)
> 
![image](https://github.com/user-attachments/assets/1eca5432-363a-4494-8156-49f8f880edd1)


## Note for Maintainer
> This is an alternative PR to #101 

## Checkout
- [x] I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading organization avatars from GitHub in addition to user avatars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->