### PR TITLE
Switched the Workflow to use Bun

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -19,10 +19,21 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: "1.1.0"
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+            .bun
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies 
+        run: bun install
 
       - name: Run ESLint
         run: bun run lint
@@ -39,10 +50,22 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: "1.1.0"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+            .bun
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
 
       - name: Build
         run: bun run build
+


### PR DESCRIPTION
## Description
- Switches from npm to Bun for verifying as npm is unable to build when there are version conflicts between two packages
- Bun is better

## Checkout
- [x] I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline migrated from Node.js/npm to Bun for dependency install and running lint/build tasks.
  * Adds caching of Bun dependencies to speed up CI and improves build/lint performance.
  * Pins Bun to a specific version for reproducible CI runs.
  * Preserves existing workflow structure, job dependencies, and timeouts.
  * No changes to application behavior or user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->