### PR TITLE
Feature show faculty name

### DIFF
--- a/components/papers/question-paper-card.tsx
+++ b/components/papers/question-paper-card.tsx
@@ -90,9 +90,13 @@ const QuestionPaperCard = ({
         <h2 className="text-xl truncate w-full" title={questionPaper.subject}>
           {questionPaper.subject}
         </h2>
-        {questionPaper.facultyName && (
-          <p className="text-sm text-muted-foreground mt-1 truncate" title={questionPaper.facultyName}>
-            Faculty: <span className="text-foreground">{questionPaper.facultyName}</span>
+        {questionPaper.facultyName?.trim() && (
+          <p
+            className="text-sm text-muted-foreground mt-1 truncate"
+            title={questionPaper.facultyName}
+          >
+            Faculty:{' '}
+            <span className="text-foreground">{questionPaper.facultyName}</span>
           </p>
         )}
       </div>

--- a/components/papers/question-paper-card.tsx
+++ b/components/papers/question-paper-card.tsx
@@ -85,10 +85,17 @@ const QuestionPaperCard = ({
   }
 
   return (
-    <Card className="w-full flex flex-col md:flex-row p-4 justify-between items-start md:items-center bg-border/20 shadow-lg hover:shadow-xl transition-shadow duration-300 ease-in-out">
-      <h2 className="text-xl truncate w-full" title={questionPaper.subject}>
-        {questionPaper.subject}
-      </h2>
+    <Card className="w-full flex flex-col md:flex-row p-4 justify-between items-start md:items-center bg-border/20 shadow-lg hover:shadow-xl transition-shadow duration-300 ease-in-out gap-4">
+      <div className="flex-1 min-w-0 w-full md:w-auto">
+        <h2 className="text-xl truncate w-full" title={questionPaper.subject}>
+          {questionPaper.subject}
+        </h2>
+        {questionPaper.facultyName && (
+          <p className="text-sm text-muted-foreground mt-1 truncate" title={questionPaper.facultyName}>
+            Faculty: <span className="text-foreground">{questionPaper.facultyName}</span>
+          </p>
+        )}
+      </div>
       <div className="flex flex-row-reverse shrink-0 md:flex-row justify-center items-center gap-4">
         <p className="text-foreground">
           {questionPaper.batch} - {questionPaper.exam} Semester{' '}


### PR DESCRIPTION
Resolves #223 .

## Description

This PR improves the accessibility and user experience by displaying the faculty name directly below the question paper title. Previously, the faculty name was only visible via a tooltip but now its showing just below the title.

Faculty Name field in the upload form (where papers are added) is just a free form text box.
This means whoever is uploading the paper just manually types exactly what they want to show up. For example, they would literally type "Prashant Sir" or "Priya Ma'am" or "Dr. Sharma" into the box, and it gets saved exactly like that into the database and displayed on the card.


## Live Demo (if any)
Before:
Faculty name was only visible on hover (tooltip)

After:
Web Development
Faculty: Prashant Sir

<img width="1461" height="150" alt="Screenshot 2026-04-11 at 1 41 07 AM" src="https://github.com/user-attachments/assets/2c1180e5-1aeb-408a-8182-a6fce40e343a" />

## Checkout
- I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Question paper cards now display optional faculty information with helpful tooltip support for additional context

* **UI/UX Improvements**
  * Improved vertical spacing and visual separation between metadata sections and action buttons on question paper cards
  * Enhanced responsive design for mobile devices and narrow viewports with improved content display and text wrapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->