### PR TITLE
feat: updated error message when uploaded file exceeds 25MB

### DIFF
--- a/app/api/papers/route.ts
+++ b/app/api/papers/route.ts
@@ -82,7 +82,7 @@ export async function POST(req: NextRequest) {
     }
     if ((file.size ?? 0) > maxBytes) {
       return NextResponse.json(
-        { message: 'File size must be less than 10MB' },
+        { message: 'File size must not exceed 10MB' },
         { status: 413 }
       )
     }

--- a/app/api/papers/route.ts
+++ b/app/api/papers/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
     }
 
     //Validate files before buffering
-    const maxBytes = 25 * 1024 * 1024
+    const maxBytes = 10 * 1024 * 1024
     const allowed = new Set([
       'application/pdf',
       'image/png',
@@ -82,7 +82,7 @@ export async function POST(req: NextRequest) {
     }
     if ((file.size ?? 0) > maxBytes) {
       return NextResponse.json(
-        { message: 'File uploaded is too large' },
+        { message: 'File size must be less than 10MB' },
         { status: 413 }
       )
     }

--- a/app/upload-papers/page.tsx
+++ b/app/upload-papers/page.tsx
@@ -134,7 +134,7 @@ const UploadPaperPage = () => {
       // Validate file size (10MB max)
       const maxSize = 10 * 1024 * 1024 // 10MB in bytes
       if (formData.uploaded_file.size > maxSize) {
-        setError('File size must be less than 10MB')
+        setError('File size must not exceed 10MB')
         setIsLoading(false)
         return
       }
@@ -466,7 +466,7 @@ const UploadPaperPage = () => {
                             : 'Click to upload file'}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          PDF, PNG, JPG, JPEG, WEBP (Max 25MB)
+                          PDF, PNG, JPG, JPEG, WEBP (Max 10MB)
                         </p>
                       </div>
                     </div>
@@ -514,7 +514,7 @@ const UploadPaperPage = () => {
               </h4>
               <ul className="space-y-1 ml-4">
                 <li>• Ensure the paper is clear and readable</li>
-                <li>• Maximum file size: 25MB</li>
+                <li>• Maximum file size: 10MB</li>
                 <li>• Supported formats: PDF, PNG, JPG, JPEG, WEBP</li>
                 <li>• All fields marked with * are required</li>
                 <li>

--- a/app/upload-papers/page.tsx
+++ b/app/upload-papers/page.tsx
@@ -131,10 +131,10 @@ const UploadPaperPage = () => {
         return
       }
 
-      // Validate file size (25MB max)
-      const maxSize = 25 * 1024 * 1024 // 25MB in bytes
+      // Validate file size (10MB max)
+      const maxSize = 10 * 1024 * 1024 // 10MB in bytes
       if (formData.uploaded_file.size > maxSize) {
-        setError('File size must be less than 25MB')
+        setError('File size must be less than 10MB')
         setIsLoading(false)
         return
       }

--- a/middleware.ts
+++ b/middleware.ts
@@ -62,8 +62,8 @@ const rateLimiterMap = rateLimiters
     }
   : {}
 
-// Maximum request size (10MB)
-const MAX_REQUEST_SIZE = 10 * 1024 * 1024
+// Maximum request size (25MB)
+const MAX_REQUEST_SIZE = 25 * 1024 * 1024
 
 export async function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname

--- a/middleware.ts
+++ b/middleware.ts
@@ -87,7 +87,7 @@ export async function middleware(request: NextRequest) {
   // Check request size
   const contentLength = request.headers.get('content-length')
   if (contentLength && parseInt(contentLength) > MAX_REQUEST_SIZE) {
-    return NextResponse.json({ message: 'Request too large' }, { status: 413 })
+    return NextResponse.json({ message: 'File size exceeds the maximum limit of 25MB. Please upload a smaller file.' }, { status: 413 })
   }
 
   // Check if the path needs rate limiting

--- a/middleware.ts
+++ b/middleware.ts
@@ -62,8 +62,8 @@ const rateLimiterMap = rateLimiters
     }
   : {}
 
-// Maximum request size (25MB)
-const MAX_REQUEST_SIZE = 25 * 1024 * 1024
+// Maximum request size (10MB)
+const MAX_REQUEST_SIZE = 10 * 1024 * 1024
 
 export async function middleware(request: NextRequest) {
   const path = request.nextUrl.pathname
@@ -87,7 +87,7 @@ export async function middleware(request: NextRequest) {
   // Check request size
   const contentLength = request.headers.get('content-length')
   if (contentLength && parseInt(contentLength) > MAX_REQUEST_SIZE) {
-    return NextResponse.json({ message: 'File size exceeds the maximum limit of 25MB. Please upload a smaller file.' }, { status: 413 })
+    return NextResponse.json({ message: 'File size exceeds the maximum limit of 10MB. Please upload a smaller file.' }, { status: 413 })
   }
 
   // Check if the path needs rate limiting


### PR DESCRIPTION
Resolves #208

## Description

>Improves the error handling for large file uploads by replacing the vague "Request too large" message with a clear and user-friendly message that explains the file size limit (25MB).

## Checkout
- [x] I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced maximum allowed upload size from 25MB to 10MB.
  * Updated oversized-upload messages to explicitly state the 10MB limit and advise uploading a smaller file.
  * Aligned client-side and server-side upload validation so users receive consistent feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->