### PR TITLE
Edited the verfiy.yml in workflows of github

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,4 +59,11 @@ jobs:
         run: pnpm install
 
       - name: Build
+        env:
+          MONGODB_URI: "mongodb://localhost:27017/dummy"
+          NEXTAUTH_SECRET: "dummy-secret-for-ci"
+          NEXTAUTH_URL: "http://localhost:3000"
+          CLOUDINARY_CLOUD_NAME: "dummy_cloud_name"
+          CLOUDINARY_API_KEY: "dummy_api_key"
+          CLOUDINARY_API_SECRET: "dummy_api_secret"
         run: pnpm build


### PR DESCRIPTION
Resolves #225 

## Description

> What is the purpose of this pull request?
The purpose of this pull request is to fix the CI build process (`pnpm build`) which was previously failing because it expected the presence of real environment variables (like `CLOUDINARY_*` and `MONGODB_URI`). 

Instead of adding actual secrets to the GitHub repository, which could potentially be leaked in CI logs or through fork PR workflows, this PR injects safely mocked, dummy environment variables directly into the `verify.yml` build step. This securely bypasses the strict environment validation during the build and allows the CI pipeline to pass without dependencies on real secrets.

## Live Demo (if any)
> If applicable, include a link or screenshots of a live demo

## Note for Maintainer
By bypassing the environment variables during the GitHub workflow using dummy data, please keep in mind:
1. **Broken PR Previews:** If this repository later uses this workflow to spin up PR preview deployments, those environments will be broken at runtime since they'd try connecting with dummy DB/Cloudinary credentials.
2. **Build-Time Fetches:** Currently, static pages build perfectly. But if any future Next.js pages attempt to run real DB queries during build-time (e.g. `generateStaticParams`), the build will fail because the mock localhost MongoDB instance won't be reachable.

## Checkout
- [X] I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD build workflow configuration to properly provision required environment settings during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->