### PR TITLE
fix: light theme flash on refreshing

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -5,6 +5,7 @@ import Header from '@/components/header'
 import AuthProvider from '@/context/session-provider'
 import { Analytics } from '@vercel/analytics/next'
 import Script from 'next/script'
+import { ThemeProvider } from '@/components/theme-provider'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -15,19 +16,20 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={
           inter.className + ' flex flex-col min-h-screen justify-between'
         }
       >
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
         <AuthProvider>
           <Header />
           {children}
           <Footer />
           <Analytics />
         </AuthProvider>
-
+        </ThemeProvider>
         {/* Google Analytics */}
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-FRS93SLW90"

--- a/components/theme-toggler.tsx
+++ b/components/theme-toggler.tsx
@@ -1,4 +1,5 @@
 'use client'
+import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
 import { FaSun, FaMoon } from 'react-icons/fa'
 
@@ -7,25 +8,17 @@ interface ThemeToggleProps {
 }
 
 export default function ThemeToggle({ text }: ThemeToggleProps) {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+  const {theme, setTheme} = useTheme()
+  const [mounted, setMounted] = useState(false)
 
-  useEffect(() => {
-    const storedTheme = localStorage.getItem('theme')
-    if (storedTheme === 'dark') {
-      setTheme('dark')
-      document.documentElement.classList.add('dark')
-    }
+    useEffect(() => {
+    setMounted(true)
   }, [])
 
-  useEffect(() => {
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark')
-      localStorage.setItem('theme', 'dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-      localStorage.setItem('theme', 'light')
-    }
-  }, [theme])
+  if (!mounted) {
+    return <button className="p-2 bg-primary flex items-center justify-center gap-3 text-white rounded cursor-pointer opacity-0">{text}</button>
+  }
+
 
   return (
     <button

--- a/components/theme-toggler.tsx
+++ b/components/theme-toggler.tsx
@@ -8,10 +8,11 @@ interface ThemeToggleProps {
 }
 
 export default function ThemeToggle({ text }: ThemeToggleProps) {
-  const {theme, setTheme} = useTheme()
+  const { theme, resolvedTheme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
+  const activeTheme = resolvedTheme ?? theme
 
-    useEffect(() => {
+  useEffect(() => {
     setMounted(true)
   }, [])
 
@@ -23,9 +24,9 @@ export default function ThemeToggle({ text }: ThemeToggleProps) {
   return (
     <button
       className="p-2 bg-primary flex items-center justify-center gap-3 text-white rounded cursor-pointer"
-      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      onClick={() => setTheme(activeTheme === 'dark' ? 'light' : 'dark')}
     >
-      {theme === 'dark' ? <FaSun /> : <FaMoon />} {text}
+      {activeTheme === 'dark' ? <FaSun /> : <FaMoon />} {text}
     </button>
   )
 }


### PR DESCRIPTION
Resolves #229

## Description

> What is the purpose of this pull request?
>The purpose of this pull request is to fix the bug in which when we switch to dark mode then refresh the site we see a flash of light mode for a second

## Live Demo

https://github.com/user-attachments/assets/a2dc9e52-b7c4-4834-b5bf-218e4bf0e1e2



## Note for Maintainer
> used "--no-verify" while committing because the script "preetier" ran out of memory therefore was unable to commit normally

## Checkout
- [x] I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated hydration warnings during page load
  * Improved theme switching stability and consistency
  * Ensured reliable initial theme selection including system default

* **Refactor**
  * Upgraded theme system for smoother transitions, better startup behavior, and improved maintainability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->