### PR TITLE
feat: semester autofill updated

### DIFF
--- a/app/upload-notes/page.tsx
+++ b/app/upload-notes/page.tsx
@@ -27,7 +27,7 @@ import { NoteCategory } from '@/types/note'
 
 const UploadNotePage = () => {
   const router = useRouter()
-  const { status } = useSession()
+  const { data: session, status } = useSession()
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [formData, setFormData] = useState({
@@ -71,6 +71,35 @@ const UploadNotePage = () => {
     }
     fetchSubjects()
   }, [])
+
+  useEffect(() => {
+    if (session?.user?.email) {
+      const email = session.user.email
+      const yearMatch = email.match(/\d{4}/)
+      const batchYear = yearMatch ? yearMatch[0] : ''
+
+      if (batchYear) {
+        const today = new Date()
+        const currentYear = today.getFullYear()
+        const currentMonth = today.getMonth() + 1
+        const joinYear = parseInt(batchYear)
+        const yearDiff = currentYear - joinYear
+
+        let calcSem = currentMonth >= 8 ? yearDiff * 2 + 1 : yearDiff * 2
+
+        if (calcSem < 1) calcSem = 1
+        if (calcSem > 8) calcSem = 8
+
+        if (formData.year === '' && formData.semester === '') {
+          setFormData((prev) => ({
+            ...prev,
+            year: batchYear,
+            semester: String(calcSem),
+          }))
+        }
+      }
+    }
+  }, [session, formData.year, formData.semester])
 
   const handleInputChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))

--- a/app/upload-notes/page.tsx
+++ b/app/upload-notes/page.tsx
@@ -153,9 +153,9 @@ const UploadNotePage = () => {
         return
       }
 
-      const maxSize = 10 * 1024 * 1024
+      const maxSize = 25 * 1024 * 1024
       if (formData.uploaded_file.size > maxSize) {
-        setError('File size must not exceed 10MB')
+        setError('File size must not exceed 25MB')
         setIsLoading(false)
         return
       }
@@ -530,7 +530,7 @@ const UploadNotePage = () => {
                       Click to upload or drag & drop
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      PDF, PNG, JPG, JPEG, WEBP · Max 10 MB
+                      PDF, PNG, JPG, JPEG, WEBP · Max 25 MB
                     </p>
                   </>
                 )}
@@ -567,7 +567,7 @@ const UploadNotePage = () => {
               for Technical Club resources
             </li>
             <li>
-              Maximum file size: <span className="text-foreground">10 MB</span>
+              Maximum file size: <span className="text-foreground">25 MB</span>
             </li>
             <li>
               Supported formats:{' '}

--- a/app/upload-notes/page.tsx
+++ b/app/upload-notes/page.tsx
@@ -153,9 +153,9 @@ const UploadNotePage = () => {
         return
       }
 
-      const maxSize = 25 * 1024 * 1024
+      const maxSize = 10 * 1024 * 1024
       if (formData.uploaded_file.size > maxSize) {
-        setError('File size must be less than 25MB')
+        setError('File size must not exceed 10MB')
         setIsLoading(false)
         return
       }
@@ -530,7 +530,7 @@ const UploadNotePage = () => {
                       Click to upload or drag & drop
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      PDF, PNG, JPG, JPEG, WEBP · Max 25 MB
+                      PDF, PNG, JPG, JPEG, WEBP · Max 10 MB
                     </p>
                   </>
                 )}
@@ -567,7 +567,7 @@ const UploadNotePage = () => {
               for Technical Club resources
             </li>
             <li>
-              Maximum file size: <span className="text-foreground">25 MB</span>
+              Maximum file size: <span className="text-foreground">10 MB</span>
             </li>
             <li>
               Supported formats:{' '}

--- a/app/upload-notes/page.tsx
+++ b/app/upload-notes/page.tsx
@@ -155,7 +155,7 @@ const UploadNotePage = () => {
 
       const maxSize = 25 * 1024 * 1024
       if (formData.uploaded_file.size > maxSize) {
-        setError('File size must not exceed 25MB')
+        setError('File size must be less than 25MB')
         setIsLoading(false)
         return
       }

--- a/app/upload-notes/page.tsx
+++ b/app/upload-notes/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useRef, useEffect } from 'react'
+import { useSemesterAutofill } from '@/hooks/useSemesterAutofill'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -72,34 +73,12 @@ const UploadNotePage = () => {
     fetchSubjects()
   }, [])
 
-  useEffect(() => {
-    if (session?.user?.email) {
-      const email = session.user.email
-      const yearMatch = email.match(/\d{4}/)
-      const batchYear = yearMatch ? yearMatch[0] : ''
-
-      if (batchYear) {
-        const today = new Date()
-        const currentYear = today.getFullYear()
-        const currentMonth = today.getMonth() + 1
-        const joinYear = parseInt(batchYear)
-        const yearDiff = currentYear - joinYear
-
-        let calcSem = currentMonth >= 8 ? yearDiff * 2 + 1 : yearDiff * 2
-
-        if (calcSem < 1) calcSem = 1
-        if (calcSem > 8) calcSem = 8
-
-        if (formData.year === '' && formData.semester === '') {
-          setFormData((prev) => ({
-            ...prev,
-            year: batchYear,
-            semester: String(calcSem),
-          }))
-        }
-      }
-    }
-  }, [session, formData.year, formData.semester])
+  useSemesterAutofill(
+    session,
+    formData.year,
+    formData.semester,
+    setFormData
+  )
 
   const handleInputChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))

--- a/app/upload-papers/page.tsx
+++ b/app/upload-papers/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useRef, useEffect } from 'react'
+import { useSemesterAutofill } from '@/hooks/useSemesterAutofill'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
@@ -75,34 +76,12 @@ const UploadPaperPage = () => {
     fetchSubjects()
   }, [])
 
-  useEffect(() => {
-    if (session?.user?.email) {
-      const email = session.user.email
-      const yearMatch = email.match(/\d{4}/)
-      const batchYear = yearMatch ? yearMatch[0] : ''
-
-      if (batchYear) {
-        const today = new Date()
-        const currentYear = today.getFullYear()
-        const currentMonth = today.getMonth() + 1
-        const joinYear = parseInt(batchYear)
-        const yearDiff = currentYear - joinYear
-
-        let calcSem = currentMonth >= 8 ? yearDiff * 2 + 1 : yearDiff * 2
-
-        if (calcSem < 1) calcSem = 1
-        if (calcSem > 8) calcSem = 8
-
-        if (formData.year === '' && formData.semester === '') {
-          setFormData((prev) => ({
-            ...prev,
-            year: batchYear,
-            semester: String(calcSem),
-          }))
-        }
-      }
-    }
-  }, [session, formData.year, formData.semester])
+  useSemesterAutofill(
+    session,
+    formData.year,
+    formData.semester,
+    setFormData
+  )
 
   const handleInputChange = (field: string, value: string) => {
     setFormData((prev) => ({
@@ -399,6 +378,7 @@ const UploadPaperPage = () => {
                     Batch(The Joining Year of the batch that gave the exam)*
                   </Label>
                   <Select
+                    value={formData.year || ''}
                     onValueChange={(value: string) =>
                       handleSelectChange('year', value)
                     }
@@ -424,6 +404,7 @@ const UploadPaperPage = () => {
                     Semester *
                   </Label>
                   <Select
+                    value={formData.semester || ''}
                     onValueChange={(value: string) =>
                       handleSelectChange('semester', value)
                     }

--- a/app/upload-papers/page.tsx
+++ b/app/upload-papers/page.tsx
@@ -163,7 +163,7 @@ const UploadPaperPage = () => {
       // Validate file size (10MB max)
       const maxSize = 10 * 1024 * 1024 // 10MB in bytes
       if (formData.uploaded_file.size > maxSize) {
-        setError('File size must be less than 10MB')
+        setError('File size must not exceed 10MB')
         setIsLoading(false)
         return
       }

--- a/app/upload-papers/page.tsx
+++ b/app/upload-papers/page.tsx
@@ -160,10 +160,10 @@ const UploadPaperPage = () => {
         return
       }
 
-      // Validate file size (25MB max)
-      const maxSize = 25 * 1024 * 1024 // 25MB in bytes
+      // Validate file size (10MB max)
+      const maxSize = 10 * 1024 * 1024 // 10MB in bytes
       if (formData.uploaded_file.size > maxSize) {
-        setError('File size must be less than 25MB')
+        setError('File size must be less than 10MB')
         setIsLoading(false)
         return
       }
@@ -495,7 +495,7 @@ const UploadPaperPage = () => {
                             : 'Click to upload file'}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          PDF, PNG, JPG, JPEG, WEBP (Max 25MB)
+                          PDF, PNG, JPG, JPEG, WEBP (Max 10MB)
                         </p>
                       </div>
                     </div>
@@ -543,7 +543,7 @@ const UploadPaperPage = () => {
               </h4>
               <ul className="space-y-1 ml-4">
                 <li>• Ensure the paper is clear and readable</li>
-                <li>• Maximum file size: 25MB</li>
+                <li>• Maximum file size: 10MB</li>
                 <li>• Supported formats: PDF, PNG, JPG, JPEG, WEBP</li>
                 <li>• All fields marked with * are required</li>
                 <li>

--- a/app/upload-papers/page.tsx
+++ b/app/upload-papers/page.tsx
@@ -75,6 +75,35 @@ const UploadPaperPage = () => {
     fetchSubjects()
   }, [])
 
+  useEffect(() => {
+    if (session?.user?.email) {
+      const email = session.user.email
+      const yearMatch = email.match(/\d{4}/)
+      const batchYear = yearMatch ? yearMatch[0] : ''
+
+      if (batchYear) {
+        const today = new Date()
+        const currentYear = today.getFullYear()
+        const currentMonth = today.getMonth() + 1
+        const joinYear = parseInt(batchYear)
+        const yearDiff = currentYear - joinYear
+
+        let calcSem = currentMonth >= 8 ? yearDiff * 2 + 1 : yearDiff * 2
+
+        if (calcSem < 1) calcSem = 1
+        if (calcSem > 8) calcSem = 8
+
+        if (formData.year === '' && formData.semester === '') {
+          setFormData((prev) => ({
+            ...prev,
+            year: batchYear,
+            semester: String(calcSem),
+          }))
+        }
+      }
+    }
+  }, [session, formData.year, formData.semester])
+
   const handleInputChange = (field: string, value: string) => {
     setFormData((prev) => ({
       ...prev,
@@ -131,10 +160,10 @@ const UploadPaperPage = () => {
         return
       }
 
-      // Validate file size (10MB max)
-      const maxSize = 10 * 1024 * 1024 // 10MB in bytes
+      // Validate file size (25MB max)
+      const maxSize = 25 * 1024 * 1024 // 25MB in bytes
       if (formData.uploaded_file.size > maxSize) {
-        setError('File size must not exceed 10MB')
+        setError('File size must be less than 25MB')
         setIsLoading(false)
         return
       }
@@ -466,7 +495,7 @@ const UploadPaperPage = () => {
                             : 'Click to upload file'}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          PDF, PNG, JPG, JPEG, WEBP (Max 10MB)
+                          PDF, PNG, JPG, JPEG, WEBP (Max 25MB)
                         </p>
                       </div>
                     </div>
@@ -514,7 +543,7 @@ const UploadPaperPage = () => {
               </h4>
               <ul className="space-y-1 ml-4">
                 <li>• Ensure the paper is clear and readable</li>
-                <li>• Maximum file size: 10MB</li>
+                <li>• Maximum file size: 25MB</li>
                 <li>• Supported formats: PDF, PNG, JPG, JPEG, WEBP</li>
                 <li>• All fields marked with * are required</li>
                 <li>

--- a/hooks/useSemesterAutofill.ts
+++ b/hooks/useSemesterAutofill.ts
@@ -1,0 +1,32 @@
+import React, { useEffect } from 'react'
+import { Session } from 'next-auth'
+
+export function useSemesterAutofill<T extends { year: string; semester: string }>(
+  session: Session | null,
+  year: string,
+  semester: string,
+  setFormData: React.Dispatch<React.SetStateAction<T>>
+) {
+  useEffect(() => {
+    if (!session?.user?.email) return
+
+    const yearMatch = session.user.email.match(/20\d{2}/)
+    const batchYear = yearMatch ? yearMatch[0] : ''
+    if (!batchYear) return
+
+    const today = new Date()
+    const currentYear = today.getFullYear()
+    const currentMonth = today.getMonth() + 1
+    const yearDiff = currentYear - parseInt(batchYear, 10)
+    let calcSem = currentMonth >= 8 ? yearDiff * 2 + 1 : yearDiff * 2
+    calcSem = Math.min(8, Math.max(1, calcSem))
+
+    if (year === '' && semester === '') {
+      setFormData((prev) => ({
+        ...prev,
+        year: batchYear,
+        semester: String(calcSem),
+      }))
+    }
+  }, [session, year, semester, setFormData])
+}


### PR DESCRIPTION
Resolves #231 .

## Description

> This PR auto-fills the Batch and Semester fields on the Upload Notes and Papers pages by using the year from the user's logged-in email

## Live Demo (if any)

<img width="914" height="656" alt="Screenshot 2026-04-12 111351" src="https://github.com/user-attachments/assets/6e84f1ee-2cf9-4fd3-9460-5f66569e1252" />

<img width="907" height="537" alt="Screenshot 2026-04-12 111329" src="https://github.com/user-attachments/assets/f085f8af-7fc1-4068-8a91-9b1efdafee91" />


## Note for Maintainer
> I added a condition inside the useEffect (if (formData.year === ''...)) . Without this check, auto-filling the semester and batch triggers the effect to run again, causing an infinite loop and crashing the page.

## Checkout
- [x] I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload forms for notes and papers now auto-fill Year and Semester from your account email when those fields are empty, using your inferred academic timeline (semester constrained to 1–8).
* **Bug Fixes**
  * Year and Semester selectors are now reliably controlled by the form state so the UI consistently reflects auto-filled values and avoids unintended overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->