### PR TITLE
feat: complete axios notes category refactoring

### DIFF
--- a/app/api/chat/messages/route.ts
+++ b/app/api/chat/messages/route.ts
@@ -157,4 +157,3 @@ export async function POST(req: Request) {
     )
   }
 }
-

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -67,11 +67,11 @@ export async function POST(req: NextRequest) {
       term = formData.get('term') as string
 
       const missingFields = []
-      if (!facultyName?.trim()) missingFields.push('facultyName')
       if (!subject?.trim()) missingFields.push('subject')
       if (!year) missingFields.push('year')
       if (!semester) missingFields.push('semester')
       if (!term?.trim()) missingFields.push('term')
+      
       if (missingFields.length > 0) {
         return NextResponse.json(
           { message: `Required fields missing: ${missingFields.join(', ')}` },

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -30,40 +30,80 @@ export async function POST(req: NextRequest) {
 
     const formData = await req.formData()
 
-    const facultyName = formData.get('facultyName') as string
     const content = formData.get('content') as string
     const subject = formData.get('subject') as string
-    const yearRaw = formData.get('year') as string
-    const year = parseInt(yearRaw ?? '', 10)
-    if (Number.isNaN(year)) {
-      return NextResponse.json({ message: 'Invalid year' }, { status: 400 })
-    }
-
-    const semesterRaw = formData.get('semester') as string
-    const semester = parseInt(semesterRaw ?? '', 10)
-    if (Number.isNaN(semester)) {
-      return NextResponse.json({ message: 'Invalid semester' }, { status: 400 })
-    }
-
-    const term = formData.get('term') as string
     const categoryRaw = formData.get('category') as string | null
     const category: 'academic' | 'axios' =
       categoryRaw === 'axios' ? 'axios' : 'academic'
     const file = formData.get('uploaded_file') as File | null
+    if (!file) {
+      return NextResponse.json({ message: 'File is required' }, { status: 400 })
+    }
 
-    if (!subject || !facultyName || !year || !semester || !term || !file) {
+    // Fields that differ by category
+    let facultyName: string | undefined
+    let year: number | undefined
+    let semester: number | undefined
+    let term: string | undefined
+    let wing: string | undefined
+    let targetAudience: string | undefined
+    let presenterName: string | undefined
+
+    if (category === 'academic') {
+      facultyName = formData.get('facultyName') as string
+      const yearRaw = formData.get('year') as string
+      year = parseInt(yearRaw ?? '', 10)
+      if (Number.isNaN(year)) {
+        return NextResponse.json({ message: 'Invalid year' }, { status: 400 })
+      }
+      const semesterRaw = formData.get('semester') as string
+      semester = parseInt(semesterRaw ?? '', 10)
+      if (Number.isNaN(semester)) {
+        return NextResponse.json(
+          { message: 'Invalid semester' },
+          { status: 400 }
+        )
+      }
+      term = formData.get('term') as string
+
       const missingFields = []
       if (!facultyName?.trim()) missingFields.push('facultyName')
       if (!subject?.trim()) missingFields.push('subject')
       if (!year) missingFields.push('year')
       if (!semester) missingFields.push('semester')
       if (!term?.trim()) missingFields.push('term')
-      if (!file) missingFields.push('file')
+      if (missingFields.length > 0) {
+        return NextResponse.json(
+          { message: `Required fields missing: ${missingFields.join(', ')}` },
+          { status: 400 }
+        )
+      }
+    } else {
+      // axios category
+      presenterName = (formData.get('presenterName') as string) || undefined
+      wing = formData.get('wing') as string
+      targetAudience = (formData.get('targetAudience') as string) || undefined
 
-      return NextResponse.json(
-        { message: `Required fields missing: ${missingFields.join(', ')}` },
-        { status: 400 }
-      )
+      const validWings = [
+        'ML',
+        'Web3',
+        'Web',
+        'FOSS',
+        'InfoSec',
+        'Design',
+        'App',
+        'CP',
+      ]
+      const missingFields = []
+      if (!subject?.trim()) missingFields.push('subject / topic')
+      if (!wing?.trim() || !validWings.includes(wing))
+        missingFields.push('wing')
+      if (missingFields.length > 0) {
+        return NextResponse.json(
+          { message: `Required fields missing: ${missingFields.join(', ')}` },
+          { status: 400 }
+        )
+      }
     }
 
     const maxBytes = 25 * 1024 * 1024
@@ -120,12 +160,11 @@ export async function POST(req: NextRequest) {
     let note
     try {
       note = await Note.create({
-        facultyName,
+        ...(category === 'academic'
+          ? { facultyName, year, semester, term }
+          : { presenterName, wing, targetAudience }),
         content,
         subject,
-        year,
-        semester,
-        term,
         category,
         document_url: cloudinaryResult.secure_url,
         storage_asset_id: cloudinaryResult.public_id,
@@ -395,8 +434,18 @@ export async function PATCH(req: NextRequest) {
     }
 
     const body = await req.json()
-    const { facultyName, content, subject, year, semester, term, category } =
-      body
+    const {
+      facultyName,
+      content,
+      subject,
+      year,
+      semester,
+      term,
+      category,
+      wing,
+      targetAudience,
+      presenterName,
+    } = body
 
     const note = await Note.findById(noteId)
     if (!note) {
@@ -456,6 +505,24 @@ export async function PATCH(req: NextRequest) {
       }
       updateData.category = category
     }
+    if (wing) {
+      const validWings = [
+        'ML',
+        'Web3',
+        'Web',
+        'FOSS',
+        'InfoSec',
+        'Design',
+        'App',
+        'CP',
+      ]
+      if (!validWings.includes(wing)) {
+        return NextResponse.json({ message: 'Invalid wing' }, { status: 400 })
+      }
+      updateData.wing = wing
+    }
+    if (targetAudience) updateData.targetAudience = targetAudience
+    if (presenterName) updateData.presenterName = presenterName
 
     updateData.$push = {
       updated_by: {

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -23,14 +23,19 @@ export default function RootLayout({ children }) {
           inter.className + ' flex flex-col min-h-screen justify-between'
         }
       >
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-        <AuthProvider>
-          <Header />
-          {children}
-          <Footer />
-          <ChatWidget />
-          <Analytics />
-        </AuthProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <AuthProvider>
+            <Header />
+            {children}
+            <Footer />
+            <ChatWidget />
+            <Analytics />
+          </AuthProvider>
         </ThemeProvider>
         {/* Google Analytics */}
         <Script

--- a/app/notes/edit/[id]/page.tsx
+++ b/app/notes/edit/[id]/page.tsx
@@ -281,6 +281,38 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
             )}
 
             <form onSubmit={handleSubmit} className="space-y-6">
+              {/* Subject Field */}
+              <div className="space-y-2">
+                <Label htmlFor="subject" className="flex items-center gap-2">
+                  <GraduationCap className="h-4 w-4" />
+                  Subject *
+                </Label>
+                <Input
+                  id="subject"
+                  type="text"
+                  placeholder="Enter the subject name"
+                  value={formData.subject}
+                  onChange={(e) => handleInputChange('subject', e.target.value)}
+                  className="w-full"
+                  required
+                />
+              </div>
+
+              {/* Content/Description Field */}
+              <div className="space-y-2">
+                <Label htmlFor="content" className="flex items-center gap-2">
+                  <BookOpen className="h-4 w-4" />
+                  Description (Optional)
+                </Label>
+                <Textarea
+                  id="content"
+                  placeholder="Describe the note content or any additional details..."
+                  value={formData.content}
+                  onChange={(e) => handleInputChange('content', e.target.value)}
+                  className="w-full min-h-[100px] resize-y"
+                />
+              </div>
+
               {formData.category === 'academic' ? (
                 <>
                   {/* Faculty Name Field */}
@@ -290,7 +322,7 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
                       className="flex items-center gap-2"
                     >
                       <FileText className="h-4 w-4" />
-                      Teaching Faculty Name (Optional)
+                      Teaching Faculty Name *
                     </Label>
                     <Input
                       id="facultyName"
@@ -301,6 +333,7 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
                         handleInputChange('facultyName', e.target.value)
                       }
                       className="w-full"
+                      required
                     />
                   </div>
 

--- a/app/notes/edit/[id]/page.tsx
+++ b/app/notes/edit/[id]/page.tsx
@@ -37,6 +37,10 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
     year: '',
     semester: '',
     term: '',
+    category: 'academic',
+    wing: '',
+    targetAudience: '',
+    presenterName: '',
   })
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
@@ -101,6 +105,10 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
         year: note.year?.toString() || '',
         semester: note.semester?.toString() || '',
         term: note.term || '',
+        category: note.category || 'academic',
+        wing: note.wing || '',
+        targetAudience: note.targetAudience || '',
+        presenterName: note.presenterName || '',
       })
     } catch (err) {
       console.error('Fetch error:', err)
@@ -134,15 +142,37 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
 
     try {
       // Validate form data
+      const isAcademic = formData.category === 'academic'
+
       if (
         !formData.subject ||
-        !formData.year ||
-        !formData.semester ||
-        !formData.term
+        (isAcademic &&
+          (!formData.year || !formData.semester || !formData.term)) ||
+        (!isAcademic && !formData.wing)
       ) {
         setError('Please fill in all required fields')
         setIsSaving(false)
         return
+      }
+
+      const updatePayload: Record<string, string> = {
+        subject: formData.subject,
+        content: formData.content,
+        // we can include all for simplicy or just filter
+        category: formData.category,
+      }
+
+      if (isAcademic) {
+        updatePayload.facultyName = formData.facultyName
+        updatePayload.year = formData.year
+        updatePayload.semester = formData.semester
+        updatePayload.term = formData.term
+      } else {
+        updatePayload.wing = formData.wing
+        if (formData.targetAudience)
+          updatePayload.targetAudience = formData.targetAudience
+        if (formData.presenterName)
+          updatePayload.presenterName = formData.presenterName
       }
 
       // Make API call
@@ -151,7 +181,7 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(formData),
+        body: JSON.stringify(updatePayload),
       })
 
       const data = await response.json()
@@ -251,139 +281,199 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
             )}
 
             <form onSubmit={handleSubmit} className="space-y-6">
-              {/* Faculty Name Field */}
-              <div className="space-y-2">
-                <Label
-                  htmlFor="facultyName"
-                  className="flex items-center gap-2"
-                >
-                  <FileText className="h-4 w-4" />
-                  Teaching Faculty Name (Optional)
-                </Label>
-                <Input
-                  id="facultyName"
-                  type="text"
-                  placeholder="Enter the teaching faculty name"
-                  value={formData.facultyName}
-                  onChange={(e) =>
-                    handleInputChange('facultyName', e.target.value)
-                  }
-                  className="w-full"
-                />
-              </div>
+              {formData.category === 'academic' ? (
+                <>
+                  {/* Faculty Name Field */}
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="facultyName"
+                      className="flex items-center gap-2"
+                    >
+                      <FileText className="h-4 w-4" />
+                      Teaching Faculty Name (Optional)
+                    </Label>
+                    <Input
+                      id="facultyName"
+                      type="text"
+                      placeholder="Enter the teaching faculty name"
+                      value={formData.facultyName}
+                      onChange={(e) =>
+                        handleInputChange('facultyName', e.target.value)
+                      }
+                      className="w-full"
+                    />
+                  </div>
 
-              {/* Content/Description Field */}
-              <div className="space-y-2">
-                <Label htmlFor="content" className="flex items-center gap-2">
-                  <BookOpen className="h-4 w-4" />
-                  Description (Optional)
-                </Label>
-                <Textarea
-                  id="content"
-                  placeholder="Describe the note content or any additional details..."
-                  value={formData.content}
-                  onChange={(e) => handleInputChange('content', e.target.value)}
-                  className="w-full min-h-[100px] resize-y"
-                />
-              </div>
+                  {/* Year and Semester Row */}
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {/* Year Field */}
+                    <div className="space-y-2">
+                      <Label htmlFor="year" className="flex items-center gap-2">
+                        <Calendar className="h-4 w-4" />
+                        Year *
+                      </Label>
+                      <Select
+                        value={formData.year}
+                        onValueChange={(value: string) =>
+                          handleSelectChange('year', value)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select year" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="2025">2025</SelectItem>
+                          <SelectItem value="2024">2024</SelectItem>
+                          <SelectItem value="2023">2023</SelectItem>
+                          <SelectItem value="2022">2022</SelectItem>
+                          <SelectItem value="2021">2021</SelectItem>
+                          <SelectItem value="2020">2020</SelectItem>
+                          <SelectItem value="2019">2019</SelectItem>
+                          <SelectItem value="2018">2018</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
 
-              {/* Subject Field */}
-              <div className="space-y-2">
-                <Label htmlFor="subject" className="flex items-center gap-2">
-                  <GraduationCap className="h-4 w-4" />
-                  Subject *
-                </Label>
-                <Input
-                  id="subject"
-                  type="text"
-                  placeholder="Enter the subject name"
-                  value={formData.subject}
-                  onChange={(e) => handleInputChange('subject', e.target.value)}
-                  className="w-full"
-                  required
-                />
-              </div>
+                    {/* Semester Field */}
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="semester"
+                        className="flex items-center gap-2"
+                      >
+                        <GraduationCap className="h-4 w-4" />
+                        Semester *
+                      </Label>
+                      <Select
+                        value={formData.semester}
+                        onValueChange={(value: string) =>
+                          handleSelectChange('semester', value)
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select semester" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="1">Semester 1</SelectItem>
+                          <SelectItem value="2">Semester 2</SelectItem>
+                          <SelectItem value="3">Semester 3</SelectItem>
+                          <SelectItem value="4">Semester 4</SelectItem>
+                          <SelectItem value="5">Semester 5</SelectItem>
+                          <SelectItem value="6">Semester 6</SelectItem>
+                          <SelectItem value="7">Semester 7</SelectItem>
+                          <SelectItem value="8">Semester 8</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
 
-              {/* Year and Semester Row */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {/* Year Field */}
-                <div className="space-y-2">
-                  <Label htmlFor="year" className="flex items-center gap-2">
-                    <Calendar className="h-4 w-4" />
-                    Year *
-                  </Label>
-                  <Select
-                    value={formData.year}
-                    onValueChange={(value: string) =>
-                      handleSelectChange('year', value)
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select year" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="2025">2025</SelectItem>
-                      <SelectItem value="2024">2024</SelectItem>
-                      <SelectItem value="2023">2023</SelectItem>
-                      <SelectItem value="2022">2022</SelectItem>
-                      <SelectItem value="2021">2021</SelectItem>
-                      <SelectItem value="2020">2020</SelectItem>
-                      <SelectItem value="2019">2019</SelectItem>
-                      <SelectItem value="2018">2018</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
+                  {/* Exam Type Field */}
+                  <div className="space-y-2">
+                    <Label htmlFor="term" className="flex items-center gap-2">
+                      <GraduationCap className="h-4 w-4" />
+                      Exam Type *
+                    </Label>
+                    <Select
+                      value={formData.term}
+                      onValueChange={(value: string) =>
+                        handleSelectChange('term', value)
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select exam type" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="Mid">Mid Semester</SelectItem>
+                        <SelectItem value="End">End Semester</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </>
+              ) : (
+                <>
+                  {/* Wing Field */}
+                  <div className="space-y-2">
+                    <Label htmlFor="wing" className="flex items-center gap-2">
+                      <GraduationCap className="h-4 w-4" />
+                      Wing *
+                    </Label>
+                    <Select
+                      value={formData.wing}
+                      onValueChange={(value: string) =>
+                        handleSelectChange('wing', value)
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select wing" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {[
+                          'ML',
+                          'Web3',
+                          'Web',
+                          'FOSS',
+                          'InfoSec',
+                          'Design',
+                          'App',
+                          'CP',
+                        ].map((w) => (
+                          <SelectItem key={w} value={w}>
+                            {w}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
 
-                {/* Semester Field */}
-                <div className="space-y-2">
-                  <Label htmlFor="semester" className="flex items-center gap-2">
-                    <GraduationCap className="h-4 w-4" />
-                    Semester *
-                  </Label>
-                  <Select
-                    value={formData.semester}
-                    onValueChange={(value: string) =>
-                      handleSelectChange('semester', value)
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select semester" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="1">Semester 1</SelectItem>
-                      <SelectItem value="2">Semester 2</SelectItem>
-                      <SelectItem value="3">Semester 3</SelectItem>
-                      <SelectItem value="4">Semester 4</SelectItem>
-                      <SelectItem value="5">Semester 5</SelectItem>
-                      <SelectItem value="6">Semester 6</SelectItem>
-                      <SelectItem value="7">Semester 7</SelectItem>
-                      <SelectItem value="8">Semester 8</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
+                  {/* Presenter Name */}
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="presenterName"
+                      className="flex items-center gap-2"
+                    >
+                      <FileText className="h-4 w-4" />
+                      Presenter (Optional)
+                    </Label>
+                    <Input
+                      id="presenterName"
+                      type="text"
+                      placeholder="e.g. John Doe"
+                      value={formData.presenterName}
+                      onChange={(e) =>
+                        handleInputChange('presenterName', e.target.value)
+                      }
+                      className="w-full"
+                    />
+                  </div>
 
-              {/* Exam Type Field */}
-              <div className="space-y-2">
-                <Label htmlFor="term" className="flex items-center gap-2">
-                  <GraduationCap className="h-4 w-4" />
-                  Exam Type *
-                </Label>
-                <Select
-                  value={formData.term}
-                  onValueChange={(value: string) =>
-                    handleSelectChange('term', value)
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select exam type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="Mid">Mid Semester</SelectItem>
-                    <SelectItem value="End">End Semester</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+                  {/* Target Audience */}
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="targetAudience"
+                      className="flex items-center gap-2"
+                    >
+                      <GraduationCap className="h-4 w-4" />
+                      Beneficial for (Optional)
+                    </Label>
+                    <Select
+                      value={formData.targetAudience}
+                      onValueChange={(value: string) =>
+                        handleSelectChange('targetAudience', value)
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select target audience" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="1st Year">1st Year</SelectItem>
+                        <SelectItem value="2nd Year">2nd Year</SelectItem>
+                        <SelectItem value="3rd Year">3rd Year</SelectItem>
+                        <SelectItem value="4th Year">4th Year</SelectItem>
+                        <SelectItem value="All">All</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </>
+              )}
 
               {/* Submit Button */}
               <div className="flex gap-4 pt-6">

--- a/app/notes/edit/[id]/page.tsx
+++ b/app/notes/edit/[id]/page.tsx
@@ -322,7 +322,7 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
                       className="flex items-center gap-2"
                     >
                       <FileText className="h-4 w-4" />
-                      Teaching Faculty Name *
+                      Teaching Faculty Name (Optional)
                     </Label>
                     <Input
                       id="facultyName"
@@ -333,7 +333,6 @@ const EditNotePage = ({ params }: { params: Promise<{ id: string }> }) => {
                         handleInputChange('facultyName', e.target.value)
                       }
                       className="w-full"
-                      required
                     />
                   </div>
 

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useEffect, useState, useMemo } from 'react'
 import NoteCard from '@/components/notes/note-card'
-import { TypeNote, NoteCategory } from '@/types/note'
+import { TypeNote, NoteCategory, AxiosWing, AxiosAudience } from '@/types/note'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import {
@@ -129,8 +129,8 @@ const Notes = () => {
     _id: string
     uploaded_by: string
     category?: string
-    wing?: string
-    targetAudience?: string
+    wing?: AxiosWing
+    targetAudience?: AxiosAudience
     presenterName?: string
   }
 
@@ -153,8 +153,8 @@ const Notes = () => {
     category: (note.category === 'axios'
       ? 'axios'
       : 'academic') as NoteCategory,
-    wing: note.wing as any,
-    targetAudience: note.targetAudience as any,
+    wing: note.wing,
+    targetAudience: note.targetAudience,
     presenterName: note.presenterName,
   })
 

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -107,6 +107,8 @@ const Notes = () => {
   const [selectedSemester, setSelectedSemester] = useState('All')
   const [selectedExam, setSelectedExam] = useState('All')
   const [selectedSubject, setSelectedSubject] = useState('All')
+  const [selectedWing, setSelectedWing] = useState('All')
+  const [selectedAudience, setSelectedAudience] = useState('All')
   const [showFilters, setShowFilters] = useState(false)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -127,6 +129,9 @@ const Notes = () => {
     _id: string
     uploaded_by: string
     category?: string
+    wing?: string
+    targetAudience?: string
+    presenterName?: string
   }
 
   const transformNote = (note: RawNote): TypeNote => ({
@@ -148,6 +153,9 @@ const Notes = () => {
     category: (note.category === 'axios'
       ? 'axios'
       : 'academic') as NoteCategory,
+    wing: note.wing as any,
+    targetAudience: note.targetAudience as any,
+    presenterName: note.presenterName,
   })
 
   const fetchNotes = async () => {
@@ -209,6 +217,8 @@ const Notes = () => {
     setSelectedSemester('All')
     setSelectedSubject('All')
     setSelectedExam('All')
+    setSelectedWing('All')
+    setSelectedAudience('All')
     setSearchQuery('')
   }
 
@@ -245,24 +255,70 @@ const Notes = () => {
   )
   const exams = ['All', 'Mid', 'End']
 
+  const wings = useMemo(
+    () => [
+      'All',
+      ...[
+        ...new Set(categoryNotes.map((n) => n.wing || '').filter(Boolean)),
+      ].sort(),
+    ],
+    [categoryNotes]
+  )
+
+  const audiences = useMemo(
+    () => [
+      'All',
+      ...[
+        ...new Set(
+          categoryNotes.map((n) => n.targetAudience || '').filter(Boolean)
+        ),
+      ].sort(),
+    ],
+    [categoryNotes]
+  )
+
   const filteredNotes = useMemo(() => {
     return categoryNotes.filter((note) => {
-      if (selectedBatch !== 'All' && note.batch.toString() !== selectedBatch)
-        return false
-      if (
-        selectedSemester !== 'All' &&
-        note.semester.toString() !== selectedSemester
-      )
-        return false
+      if (activeCategory === 'academic') {
+        if (selectedBatch !== 'All' && note.batch.toString() !== selectedBatch)
+          return false
+        if (
+          selectedSemester !== 'All' &&
+          note.semester.toString() !== selectedSemester
+        )
+          return false
+        if (selectedExam !== 'All' && note.exam !== selectedExam) return false
+      } else if (activeCategory === 'axios') {
+        if (selectedWing !== 'All' && note.wing !== selectedWing) return false
+        if (
+          selectedAudience !== 'All' &&
+          note.targetAudience !== selectedAudience
+        )
+          return false
+      }
+
       if (selectedSubject !== 'All' && note.subject !== selectedSubject)
         return false
-      if (selectedExam !== 'All' && note.exam !== selectedExam) return false
-      if (
-        searchQuery.trim() &&
-        !note.subject.toLowerCase().includes(searchQuery.toLowerCase()) &&
-        !note.facultyName.toLowerCase().includes(searchQuery.toLowerCase())
-      )
-        return false
+
+      if (searchQuery.trim()) {
+        const query = searchQuery.toLowerCase()
+        const matchTitle = note.subject.toLowerCase().includes(query)
+        const matchFaculty = note.facultyName?.toLowerCase().includes(query)
+        const matchDescription = note.description?.toLowerCase().includes(query)
+        const matchPresenter = note.presenterName?.toLowerCase().includes(query)
+        const matchWing = note.wing?.toLowerCase().includes(query)
+
+        if (
+          !matchTitle &&
+          !matchFaculty &&
+          !matchDescription &&
+          !matchPresenter &&
+          !matchWing
+        ) {
+          return false
+        }
+      }
+
       return true
     })
   }, [
@@ -271,7 +327,10 @@ const Notes = () => {
     selectedSemester,
     selectedSubject,
     selectedExam,
+    selectedWing,
+    selectedAudience,
     searchQuery,
+    activeCategory,
   ])
 
   const hasActiveFilters =
@@ -279,6 +338,8 @@ const Notes = () => {
     selectedSemester !== 'All' ||
     selectedSubject !== 'All' ||
     selectedExam !== 'All' ||
+    selectedWing !== 'All' ||
+    selectedAudience !== 'All' ||
     searchQuery.trim() !== ''
 
   return (
@@ -348,7 +409,11 @@ const Notes = () => {
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
               <input
                 type="text"
-                placeholder="Search by subject or faculty…"
+                placeholder={
+                  activeCategory === 'axios'
+                    ? 'Search by wing or subject…'
+                    : 'Search by subject or faculty…'
+                }
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="w-full pl-9 pr-4 py-2 rounded-md border border-input bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring transition-all"
@@ -384,24 +449,43 @@ const Notes = () => {
                 options={subjects}
                 onChange={setSelectedSubject}
               />
-              <FilterDropdown
-                label="Batch"
-                value={selectedBatch}
-                options={batches}
-                onChange={setSelectedBatch}
-              />
-              <FilterDropdown
-                label="Semester"
-                value={selectedSemester}
-                options={semesters}
-                onChange={setSelectedSemester}
-              />
-              <FilterDropdown
-                label="Exam Type"
-                value={selectedExam}
-                options={exams}
-                onChange={setSelectedExam}
-              />
+              {activeCategory === 'academic' ? (
+                <>
+                  <FilterDropdown
+                    label="Batch"
+                    value={selectedBatch}
+                    options={batches}
+                    onChange={setSelectedBatch}
+                  />
+                  <FilterDropdown
+                    label="Semester"
+                    value={selectedSemester}
+                    options={semesters}
+                    onChange={setSelectedSemester}
+                  />
+                  <FilterDropdown
+                    label="Exam Type"
+                    value={selectedExam}
+                    options={exams}
+                    onChange={setSelectedExam}
+                  />
+                </>
+              ) : (
+                <>
+                  <FilterDropdown
+                    label="Wing"
+                    value={selectedWing}
+                    options={wings}
+                    onChange={setSelectedWing}
+                  />
+                  <FilterDropdown
+                    label="Beneficial for"
+                    value={selectedAudience}
+                    options={audiences}
+                    onChange={setSelectedAudience}
+                  />
+                </>
+              )}
             </div>
           )}
         </div>

--- a/app/quick-reads/page.tsx
+++ b/app/quick-reads/page.tsx
@@ -83,21 +83,30 @@ const markdownComponents = {
   },
   h1({ node, children, ...props }: MarkdownComponentProps) {
     return (
-      <h1 className="text-2xl font-bold mb-2 mt-4 text-gray-900 dark:text-gray-100" {...props}>
+      <h1
+        className="text-2xl font-bold mb-2 mt-4 text-gray-900 dark:text-gray-100"
+        {...props}
+      >
         {children}
       </h1>
     )
   },
   h2({ node, children, ...props }: MarkdownComponentProps) {
     return (
-      <h2 className="text-xl font-bold mb-1.5 mt-3 text-gray-900 dark:text-gray-100" {...props}>
+      <h2
+        className="text-xl font-bold mb-1.5 mt-3 text-gray-900 dark:text-gray-100"
+        {...props}
+      >
         {children}
       </h2>
     )
   },
   h3({ node, children, ...props }: MarkdownComponentProps) {
     return (
-      <h3 className="text-lg font-bold mb-1 mt-2 text-gray-900 dark:text-gray-100" {...props}>
+      <h3
+        className="text-lg font-bold mb-1 mt-2 text-gray-900 dark:text-gray-100"
+        {...props}
+      >
         {children}
       </h3>
     )
@@ -585,13 +594,28 @@ export default function QuickReads() {
             <div className="bg-yellow-100 dark:bg-yellow-500/20 p-1 rounded-md shrink-0 mt-0.5">
               <ClipboardList className="h-4 w-4 text-yellow-700 dark:text-yellow-400" />
             </div>
-            <p className="text-sm font-medium leading-relaxed mt-0.5">{toast}</p>
+            <p className="text-sm font-medium leading-relaxed mt-0.5">
+              {toast}
+            </p>
             <button
               onClick={() => setToast(null)}
               aria-label="Close toast"
               className="ml-auto text-yellow-600 dark:text-yellow-500 hover:text-yellow-800 dark:hover:text-yellow-300 mt-0.5"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
             </button>
           </div>
         </div>

--- a/app/upload-notes/page.tsx
+++ b/app/upload-notes/page.tsx
@@ -40,6 +40,9 @@ const UploadNotePage = () => {
     term: '',
     category: 'academic' as NoteCategory,
     uploaded_file: null as File | null,
+    wing: '',
+    targetAudience: '',
+    presenterName: '',
   })
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -73,12 +76,7 @@ const UploadNotePage = () => {
     fetchSubjects()
   }, [])
 
-  useSemesterAutofill(
-    session,
-    formData.year,
-    formData.semester,
-    setFormData
-  )
+  useSemesterAutofill(session, formData.year, formData.semester, setFormData)
 
   const handleInputChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
@@ -119,13 +117,17 @@ const UploadNotePage = () => {
     try {
       const finalSubject = isNewSubject ? customSubject : formData.subject
 
+      const isAcademic = formData.category === 'academic'
+
       if (
         !finalSubject ||
-        !formData.facultyName ||
-        !formData.year ||
-        !formData.semester ||
-        !formData.term ||
-        !formData.uploaded_file
+        !formData.uploaded_file ||
+        (isAcademic &&
+          (!formData.facultyName ||
+            !formData.year ||
+            !formData.semester ||
+            !formData.term)) ||
+        (!isAcademic && !formData.wing)
       ) {
         setError('Please fill in all required fields')
         setIsLoading(false)
@@ -152,14 +154,25 @@ const UploadNotePage = () => {
       }
 
       const submitFormData = new FormData()
-      submitFormData.append('facultyName', formData.facultyName)
       submitFormData.append('content', formData.content)
       submitFormData.append('subject', finalSubject)
-      submitFormData.append('year', formData.year)
-      submitFormData.append('semester', formData.semester)
-      submitFormData.append('term', formData.term)
       submitFormData.append('category', formData.category)
       submitFormData.append('uploaded_file', formData.uploaded_file)
+
+      if (isAcademic) {
+        submitFormData.append('facultyName', formData.facultyName)
+        submitFormData.append('year', formData.year)
+        submitFormData.append('semester', formData.semester)
+        submitFormData.append('term', formData.term)
+      } else {
+        submitFormData.append('wing', formData.wing)
+        if (formData.targetAudience) {
+          submitFormData.append('targetAudience', formData.targetAudience)
+        }
+        if (formData.presenterName) {
+          submitFormData.append('presenterName', formData.presenterName)
+        }
+      }
 
       const response = await fetch('/api/notes', {
         method: 'POST',
@@ -187,6 +200,9 @@ const UploadNotePage = () => {
         term: '',
         category: 'academic',
         uploaded_file: null,
+        wing: '',
+        targetAudience: '',
+        presenterName: '',
       })
       setCustomSubject('')
       setIsNewSubject(false)
@@ -338,112 +354,229 @@ const UploadNotePage = () => {
             )}
           </div>
 
-          {/* Faculty Name */}
-          <div className="space-y-2">
-            <label
-              htmlFor="facultyName"
-              className="flex items-center gap-2 text-sm font-medium"
-            >
-              <FileText className="w-4 h-4" />
-              Teaching Faculty Name *
-            </label>
-            <Input
-              id="facultyName"
-              type="text"
-              placeholder="e.g. Dr. Rajan Kumar"
-              value={formData.facultyName}
-              onChange={(e) => handleInputChange('facultyName', e.target.value)}
-              required
-            />
-          </div>
+          {/* Academic / Axios specific fields */}
+          {formData.category === 'academic' ? (
+            <>
+              {/* Faculty Name */}
+              <div className="space-y-2">
+                <label
+                  htmlFor="facultyName"
+                  className="flex items-center gap-2 text-sm font-medium"
+                >
+                  <FileText className="w-4 h-4" />
+                  Teaching Faculty Name *
+                </label>
+                <Input
+                  id="facultyName"
+                  type="text"
+                  placeholder="e.g. Dr. Rajan Kumar"
+                  value={formData.facultyName}
+                  onChange={(e) =>
+                    handleInputChange('facultyName', e.target.value)
+                  }
+                  required={formData.category === 'academic'}
+                />
+              </div>
 
-          {/* Description */}
-          <div className="space-y-2">
-            <label
-              htmlFor="content"
-              className="flex items-center gap-2 text-sm font-medium"
-            >
-              <BookOpen className="w-4 h-4" />
-              Description
-              <span className="text-muted-foreground text-xs font-normal">
-                (optional)
-              </span>
-            </label>
-            <Textarea
-              id="content"
-              placeholder="Brief description of the note content…"
-              value={formData.content}
-              onChange={(e) => handleInputChange('content', e.target.value)}
-              className="min-h-[80px] resize-y"
-            />
-          </div>
+              {/* Description */}
+              <div className="space-y-2">
+                <label
+                  htmlFor="content"
+                  className="flex items-center gap-2 text-sm font-medium"
+                >
+                  <BookOpen className="w-4 h-4" />
+                  Description
+                  <span className="text-muted-foreground text-xs font-normal">
+                    (optional)
+                  </span>
+                </label>
+                <Textarea
+                  id="content"
+                  placeholder="Brief description of the note content…"
+                  value={formData.content}
+                  onChange={(e) => handleInputChange('content', e.target.value)}
+                  className="min-h-[80px] resize-y"
+                />
+              </div>
 
-          {/* Batch + Semester */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <label className="flex items-center gap-2 text-sm font-medium">
-                <Calendar className="w-4 h-4" />
-                Batch (Joining Year) *
-              </label>
-              <Select
-                value={formData.year || ''}
-                onValueChange={(v) => handleSelectChange('year', v)}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select year" />
-                </SelectTrigger>
-                <SelectContent>
-                  {[2026, 2025, 2024, 2023, 2022, 2021].map((y) => (
-                    <SelectItem key={y} value={String(y)}>
-                      {y}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+              {/* Batch + Semester */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2 text-sm font-medium">
+                    <Calendar className="w-4 h-4" />
+                    Batch (Joining Year) *
+                  </label>
+                  <Select
+                    value={formData.year || ''}
+                    onValueChange={(v) => handleSelectChange('year', v)}
+                    required={formData.category === 'academic'}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select year" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[2026, 2025, 2024, 2023, 2022, 2021].map((y) => (
+                        <SelectItem key={y} value={String(y)}>
+                          {y}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
 
-            <div className="space-y-2">
-              <label className="flex items-center gap-2 text-sm font-medium">
-                <GraduationCap className="w-4 h-4" />
-                Semester *
-              </label>
-              <Select
-                value={formData.semester || ''}
-                onValueChange={(v) => handleSelectChange('semester', v)}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select semester" />
-                </SelectTrigger>
-                <SelectContent>
-                  {[1, 2, 3, 4, 5, 6, 7, 8].map((s) => (
-                    <SelectItem key={s} value={String(s)}>
-                      Semester {s}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2 text-sm font-medium">
+                    <GraduationCap className="w-4 h-4" />
+                    Semester *
+                  </label>
+                  <Select
+                    value={formData.semester || ''}
+                    onValueChange={(v) => handleSelectChange('semester', v)}
+                    required={formData.category === 'academic'}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select semester" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {[1, 2, 3, 4, 5, 6, 7, 8].map((s) => (
+                        <SelectItem key={s} value={String(s)}>
+                          Semester {s}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
 
-          {/* Exam Type */}
-          <div className="space-y-2">
-            <label className="flex items-center gap-2 text-sm font-medium">
-              <GraduationCap className="w-4 h-4" />
-              Exam Type *
-            </label>
-            <Select
-              value={formData.term || ''}
-              onValueChange={(v) => handleSelectChange('term', v)}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select exam type" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="Mid">Mid Semester</SelectItem>
-                <SelectItem value="End">End Semester</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+              {/* Exam Type */}
+              <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm font-medium">
+                  <GraduationCap className="w-4 h-4" />
+                  Exam Type *
+                </label>
+                <Select
+                  value={formData.term || ''}
+                  onValueChange={(v) => handleSelectChange('term', v)}
+                  required={formData.category === 'academic'}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select exam type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="Mid">Mid Semester</SelectItem>
+                    <SelectItem value="End">End Semester</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </>
+          ) : (
+            <>
+              {/* Wing */}
+              <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm font-medium">
+                  <GraduationCap className="w-4 h-4" />
+                  Wing *
+                </label>
+                <Select
+                  value={formData.wing || ''}
+                  onValueChange={(v) => handleSelectChange('wing', v)}
+                  required={formData.category === 'axios'}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select wing" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[
+                      'ML',
+                      'Web3',
+                      'Web',
+                      'FOSS',
+                      'InfoSec',
+                      'Design',
+                      'App',
+                      'CP',
+                    ].map((w) => (
+                      <SelectItem key={w} value={w}>
+                        {w}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Presenter Name */}
+              <div className="space-y-2">
+                <label
+                  htmlFor="presenterName"
+                  className="flex items-center gap-2 text-sm font-medium"
+                >
+                  <FileText className="w-4 h-4" />
+                  Presenter
+                  <span className="text-muted-foreground text-xs font-normal">
+                    (optional)
+                  </span>
+                </label>
+                <Input
+                  id="presenterName"
+                  type="text"
+                  placeholder="e.g. John Doe"
+                  value={formData.presenterName}
+                  onChange={(e) =>
+                    handleInputChange('presenterName', e.target.value)
+                  }
+                />
+              </div>
+
+              {/* Target Audience / Beneficial for */}
+              <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm font-medium">
+                  <GraduationCap className="w-4 h-4" />
+                  Beneficial for
+                  <span className="text-muted-foreground text-xs font-normal">
+                    (optional)
+                  </span>
+                </label>
+                <Select
+                  value={formData.targetAudience}
+                  onValueChange={(value) =>
+                    handleSelectChange('targetAudience', value)
+                  }
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select target audience" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="1st Year">1st Year</SelectItem>
+                    <SelectItem value="2nd Year">2nd Year</SelectItem>
+                    <SelectItem value="3rd Year">3rd Year</SelectItem>
+                    <SelectItem value="4th Year">4th Year</SelectItem>
+                    <SelectItem value="All">All</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Description */}
+              <div className="space-y-2">
+                <label
+                  htmlFor="content_axios"
+                  className="flex items-center gap-2 text-sm font-medium"
+                >
+                  <BookOpen className="w-4 h-4" />
+                  Description
+                  <span className="text-muted-foreground text-xs font-normal">
+                    (optional)
+                  </span>
+                </label>
+                <Textarea
+                  id="content_axios"
+                  placeholder="Brief description of the note content…"
+                  value={formData.content}
+                  onChange={(e) => handleInputChange('content', e.target.value)}
+                  className="min-h-[80px] resize-y"
+                />
+              </div>
+            </>
+          )}
 
           {/* File Upload */}
           <div className="space-y-2">

--- a/app/upload-notes/page.tsx
+++ b/app/upload-notes/page.tsx
@@ -364,7 +364,7 @@ const UploadNotePage = () => {
                   className="flex items-center gap-2 text-sm font-medium"
                 >
                   <FileText className="w-4 h-4" />
-                  Teaching Faculty Name *
+                  Teaching Faculty Name (Optional)
                 </label>
                 <Input
                   id="facultyName"
@@ -374,7 +374,6 @@ const UploadNotePage = () => {
                   onChange={(e) =>
                     handleInputChange('facultyName', e.target.value)
                   }
-                  required={formData.category === 'academic'}
                 />
               </div>
 

--- a/app/upload-papers/page.tsx
+++ b/app/upload-papers/page.tsx
@@ -76,12 +76,7 @@ const UploadPaperPage = () => {
     fetchSubjects()
   }, [])
 
-  useSemesterAutofill(
-    session,
-    formData.year,
-    formData.semester,
-    setFormData
-  )
+  useSemesterAutofill(session, formData.year, formData.semester, setFormData)
 
   const handleInputChange = (field: string, value: string) => {
     setFormData((prev) => ({

--- a/components/chat/ChatWidget.tsx
+++ b/components/chat/ChatWidget.tsx
@@ -244,4 +244,3 @@ function ChatWidgetInner() {
     </>
   )
 }
-

--- a/components/notes/note-card.tsx
+++ b/components/notes/note-card.tsx
@@ -76,29 +76,67 @@ const NoteCard = ({ note, onDelete }: NoteCardProps) => {
         >
           {note.subject}
         </h3>
-        <p className="text-xs sm:text-sm text-muted-foreground mt-0.5 truncate">
-          Faculty:{' '}
-          <span className="text-foreground">{note.facultyName || 'N/A'}</span>
-          {note.description && (
-            <>
-              {' '}
-              · <span className="italic">{note.description}</span>
-            </>
-          )}
-        </p>
+        {note.category === 'axios' ? (
+          <>
+            <p className="text-xs sm:text-sm text-muted-foreground mt-0.5 truncate">
+              Presenter:{' '}
+              <span className="text-foreground">
+                {note.presenterName || 'N/A'}
+              </span>
+              {note.description && (
+                <>
+                  {' '}
+                  · <span className="italic">{note.description}</span>
+                </>
+              )}
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="text-xs sm:text-sm text-muted-foreground mt-0.5 truncate">
+              Faculty:{' '}
+              <span className="text-foreground">
+                {note.facultyName || 'N/A'}
+              </span>
+              {note.description && (
+                <>
+                  {' '}
+                  · <span className="italic">{note.description}</span>
+                </>
+              )}
+            </p>
+          </>
+        )}
       </div>
 
       {/* Meta badges */}
       <div className="flex flex-wrap items-center gap-1.5 flex-shrink-0">
-        <span className="inline-flex items-center px-2 sm:px-3 py-0.5 sm:py-1 rounded text-xs sm:text-sm font-medium bg-background border border-border text-muted-foreground">
-          Sem {note.semester}
-        </span>
-        <span className="inline-flex items-center px-2 sm:px-3 py-0.5 sm:py-1 rounded text-xs sm:text-sm font-medium bg-background border border-border text-muted-foreground">
-          {note.exam}
-        </span>
-        <span className="inline-flex items-center px-2 sm:px-3 py-0.5 sm:py-1 rounded text-xs sm:text-sm font-medium bg-background border border-border text-muted-foreground">
-          {note.batch}
-        </span>
+        {note.category === 'axios' ? (
+          <>
+            {note.wing && (
+              <span className="inline-flex items-center px-2 sm:px-3 py-0.5 sm:py-1 rounded text-xs sm:text-sm font-medium bg-background border border-border text-muted-foreground">
+                {note.wing}
+              </span>
+            )}
+            {note.targetAudience && (
+              <span className="inline-flex items-center px-2 sm:px-3 py-0.5 sm:py-1 rounded text-xs sm:text-sm font-medium bg-background border border-border text-muted-foreground">
+                {note.targetAudience}
+              </span>
+            )}
+          </>
+        ) : (
+          <>
+            <span className="inline-flex items-center px-2 sm:px-3 py-0.5 sm:py-1 rounded text-xs sm:text-sm font-medium bg-background border border-border text-muted-foreground">
+              Sem {note.semester}
+            </span>
+            <span className="inline-flex items-center px-2 sm:px-3 py-0.5 sm:py-1 rounded text-xs sm:text-sm font-medium bg-background border border-border text-muted-foreground">
+              {note.exam}
+            </span>
+            <span className="inline-flex items-center px-2 sm:px-3 py-0.5 sm:py-1 rounded text-xs sm:text-sm font-medium bg-background border border-border text-muted-foreground">
+              {note.batch}
+            </span>
+          </>
+        )}
       </div>
 
       {/* Actions */}
@@ -113,7 +151,9 @@ const NoteCard = ({ note, onDelete }: NoteCardProps) => {
           </button>
           <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-64 p-3 bg-popover text-popover-foreground text-sm rounded-md shadow-md border z-50 invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-all duration-200 pointer-events-none">
             <div className="font-semibold mb-1">
-              Faculty: {note.facultyName || 'N/A'}
+              {note.category === 'axios'
+                ? `Presenter: ${note.presenterName || 'N/A'}`
+                : `Faculty: ${note.facultyName || 'N/A'}`}
             </div>
             <div className="text-muted-foreground text-xs">
               {note.description || 'No description available'}

--- a/components/theme-toggler.tsx
+++ b/components/theme-toggler.tsx
@@ -17,9 +17,12 @@ export default function ThemeToggle({ text }: ThemeToggleProps) {
   }, [])
 
   if (!mounted) {
-    return <button className="p-2 bg-primary flex items-center justify-center gap-3 text-white rounded cursor-pointer opacity-0">{text}</button>
+    return (
+      <button className="p-2 bg-primary flex items-center justify-center gap-3 text-white rounded cursor-pointer opacity-0">
+        {text}
+      </button>
+    )
   }
-
 
   return (
     <button

--- a/hooks/useChatMessages.ts
+++ b/hooks/useChatMessages.ts
@@ -432,4 +432,3 @@ export function useChatMessages(options: UseChatMessagesOptions = {}) {
     inputRef,
   }
 }
-

--- a/hooks/useSemesterAutofill.ts
+++ b/hooks/useSemesterAutofill.ts
@@ -1,7 +1,9 @@
 import React, { useEffect } from 'react'
 import { Session } from 'next-auth'
 
-export function useSemesterAutofill<T extends { year: string; semester: string }>(
+export function useSemesterAutofill<
+  T extends { year: string; semester: string },
+>(
   session: Session | null,
   year: string,
   semester: string,

--- a/lib/eventEmitter.ts
+++ b/lib/eventEmitter.ts
@@ -43,4 +43,3 @@ export const chatEmitter = globalForEvents.chatEmitter || new EventEmitter()
 if (process.env.NODE_ENV !== 'production') {
   globalForEvents.chatEmitter = chatEmitter
 }
-

--- a/middleware.ts
+++ b/middleware.ts
@@ -88,7 +88,13 @@ export async function middleware(request: NextRequest) {
   // Check request size
   const contentLength = request.headers.get('content-length')
   if (contentLength && parseInt(contentLength) > MAX_REQUEST_SIZE) {
-    return NextResponse.json({ message: 'File size exceeds the maximum limit of 10MB. Please upload a smaller file.' }, { status: 413 })
+    return NextResponse.json(
+      {
+        message:
+          'File size exceeds the maximum limit of 10MB. Please upload a smaller file.',
+      },
+      { status: 413 }
+    )
   }
 
   // Check if the path needs rate limiting

--- a/model/Message.ts
+++ b/model/Message.ts
@@ -80,4 +80,3 @@ const MessageSchema = new mongoose.Schema<IMessage>({
 const Message: Model<IMessage> =
   mongoose.models.Message || mongoose.model<IMessage>('Message', MessageSchema)
 export default Message
-

--- a/model/note.ts
+++ b/model/note.ts
@@ -7,13 +7,17 @@ export interface INoteUpdate {
 }
 
 export interface INote extends Document {
-  facultyName: string
+  facultyName?: string
   content?: string
   subject: string
-  year: number
-  semester: number
-  term: string
+  year?: number
+  semester?: number
+  term?: string
   category: 'academic' | 'axios'
+  // Axios-specific
+  wing?: 'ML' | 'Web3' | 'Web' | 'FOSS' | 'InfoSec' | 'Design' | 'App' | 'CP'
+  targetAudience?: '1st Year' | '2nd Year' | '3rd Year' | '4th Year' | 'All'
+  presenterName?: string
   document_url: string
   storage_asset_id: string
   file_name: string
@@ -26,7 +30,6 @@ const NoteSchema: Schema<INote> = new Schema<INote>(
   {
     facultyName: {
       type: String,
-      required: [true, 'Faculty name is mandatory for notes'],
       trim: true,
       maxlength: [100, 'Faculty name must be withing 100 characters'],
     },
@@ -41,7 +44,6 @@ const NoteSchema: Schema<INote> = new Schema<INote>(
     },
     year: {
       type: Number,
-      required: [true, 'Year of note is necessary'],
       validate: {
         validator: (v: number) =>
           Number.isInteger(v) && v >= 2015 && v <= new Date().getFullYear(),
@@ -50,7 +52,6 @@ const NoteSchema: Schema<INote> = new Schema<INote>(
     },
     semester: {
       type: Number,
-      required: [true, 'Semester is required'],
       validate: {
         validator: (v: number) => Number.isInteger(v) && v >= 1 && v <= 8,
         message: 'Semester must be an integer between 1 and 8',
@@ -59,13 +60,26 @@ const NoteSchema: Schema<INote> = new Schema<INote>(
     term: {
       type: String,
       enum: ['Mid', 'End'],
-      required: [true, 'Exam type (term) is required'],
       set: (v: string) => v.charAt(0).toUpperCase() + v.slice(1).toLowerCase(),
     },
     category: {
       type: String,
       enum: ['academic', 'axios'],
       default: 'academic',
+    },
+    // Axios-specific fields
+    wing: {
+      type: String,
+      enum: ['ML', 'Web3', 'Web', 'FOSS', 'InfoSec', 'Design', 'App', 'CP'],
+    },
+    targetAudience: {
+      type: String,
+      enum: ['1st Year', '2nd Year', '3rd Year', '4th Year', 'All'],
+    },
+    presenterName: {
+      type: String,
+      trim: true,
+      maxlength: [100, 'Presenter name must be within 100 characters'],
     },
     document_url: {
       type: String,
@@ -107,6 +121,23 @@ const NoteSchema: Schema<INote> = new Schema<INote>(
 )
 
 NoteSchema.plugin(aggregatePaginate)
+
+// Conditional validation: academic notes require year, semester, term
+// Axios notes require wing
+NoteSchema.pre('validate', function (next) {
+  if (this.category === 'academic') {
+    if (!this.year) {
+      this.invalidate('year', 'Year is required for academic notes')
+    }
+    if (!this.semester) {
+      this.invalidate('semester', 'Semester is required for academic notes')
+    }
+    if (!this.term) {
+      this.invalidate('term', 'Exam type is required for academic notes')
+    }
+  }
+  next()
+})
 
 const Note: Model<INote> =
   mongoose.models.Note || mongoose.model<INote>('Note', NoteSchema)

--- a/types/note.d.ts
+++ b/types/note.d.ts
@@ -1,5 +1,22 @@
 export type NoteCategory = 'academic' | 'axios'
 
+export type AxiosWing =
+  | 'ML'
+  | 'Web3'
+  | 'Web'
+  | 'FOSS'
+  | 'InfoSec'
+  | 'Design'
+  | 'App'
+  | 'CP'
+
+export type AxiosAudience =
+  | '1st Year'
+  | '2nd Year'
+  | '3rd Year'
+  | '4th Year'
+  | 'All'
+
 export type TypeNote = {
   subject: string
   subjectCode: string
@@ -15,4 +32,8 @@ export type TypeNote = {
   description?: string
   facultyName: string
   category?: NoteCategory
+  // Axios-specific fields
+  wing?: AxiosWing
+  targetAudience?: AxiosAudience
+  presenterName?: string
 }


### PR DESCRIPTION
Resolves #236 

## Description

- Added Functionality to Axios Notes Section
- Notes can be added/filtered by Wing, Subject and Year


## Live Demo (if any)
<img width="1897" height="393" alt="Screenshot 2026-04-12 183700" src="https://github.com/user-attachments/assets/cf338643-79ce-400c-979a-8039f5293ca0" />
<img width="941" height="764" alt="Screenshot 2026-04-12 174628" src="https://github.com/user-attachments/assets/5a4635cf-aac7-4d70-92a6-365376d3fdf8" />


## Note for Maintainer
- Due to lack of Data in local database, I was unable to test features correctly.
- I would appreciate a thorough review or assistance with testing in a staged environment to ensure everything works as planned.

## Checkout
- [x] I have read all the contributor guidelines for the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Axios (non-academic) notes with wing, presenter name, and target audience fields.
  * Notes form and edit UI now show category-specific inputs and validation.
  * Notes page gains category-aware filtering and search (wing/presenter/targetAudience included).
  * Note cards display metadata relevant to the note category.

* **Bug Fixes / Improvements**
  * Stronger upload/edit validation with clearer error responses.
  * Minor UI/formatting cleanup for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->